### PR TITLE
Fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,9 +221,9 @@
         <li>If <code>A</code>.node is an RDF graph, <code>A</code> is in the fixed ShapeMap.</li>
         <li>If <code>A</code>.node is a <a>triple pattern</a>, let <code>P</code> be a <a href="https://www.w3.org/TR/sparql11-query/#defn_TriplePattern">SPARQL Triple Pattern</a> where
         <ul>
-          <li>If <code>A</code>'s subject is a <a>focus selector</a> or a <a>wildcard</a>, <code>P</code>'s  subject is a fresh variable, otherwise <code>P</code>'s subect is <code>A</code>'s subject.</li>
+          <li>If <code>A</code>'s subject is a <a>focus selector</a> or a <a>wildcard</a>, <code>P</code>'s  subject is a fresh variable, otherwise <code>P</code>'s subject is <code>A</code>'s subject.</li>
           <li><code>P</code>'s predicate is <code>A</code>'s predicate.</li>
-          <li>If <code>A</code>'s object is a <a>focus selector</a> or a <a>wildcard</a>, <code>P</code>'s  object is a fresh variable, otherwise <code>P</code>'s subect is <code>A</code>'s object.</li>
+          <li>If <code>A</code>'s object is a <a>focus selector</a> or a <a>wildcard</a>, <code>P</code>'s  object is a fresh variable, otherwise <code>P</code>'s subject is <code>A</code>'s object.</li>
         </ul>
         </li>
       </ul>


### PR DESCRIPTION
“subject” was misspelled as “subect” twice.